### PR TITLE
Allow custom Docker image name and tag for network map and Corda nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,12 @@ cache:
   directories:
     - "$HOME/.gradle/caches/"
     - "$HOME/.gradle/wrapper/"
-    - "/var/lib/docker/"
 install: skip
 test: skip
 jobs:
   include:
     - stage: build pull request
-      script: "./gradlew spotlessCheck check integrationTest jacocoTestReport"
+      script: "./gradlew spotlessCheck check jacocoTestReport"
       if: type = pull_request
     - stage: build master
       script: "./gradlew spotlessCheck check jacocoTestReport publishAllPublicationsToSnapshotsRepository"

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/ContainerCoordinates.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/ContainerCoordinates.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.corda.network
+
+/**
+ * A Docker container image specification.
+ */
+open class ContainerCoordinates(
+    open val organisation: String,
+    open val image: String,
+    open val tag: String
+) {
+    override fun toString() = "$organisation/$image:$tag"
+}

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/ContainerLifecycle.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/ContainerLifecycle.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.corda.network
+
+interface ContainerLifecycle {
+    /**
+     * Start this container.
+     */
+    fun start()
+
+    /**
+     * Stop this container.
+     */
+    fun stop()
+}

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -24,7 +24,7 @@ import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
 import org.testcontainers.containers.Network
 import org.web3j.corda.network.CordaNetworkMap.Companion.DEFAULT_IMAGE
 import org.web3j.corda.network.CordaNetworkMap.Companion.DEFAULT_TAG
-import org.web3j.corda.network.CordaNetworkMap.Companion.ORGANIZATION
+import org.web3j.corda.network.CordaNetworkMap.Companion.DEFAULT_ORGANIZATION
 import org.web3j.corda.networkmap.NetworkMapApi
 import org.web3j.corda.protocol.CordaService
 import org.web3j.corda.util.OpenApiVersion.v3_0_1
@@ -36,7 +36,7 @@ import org.web3j.corda.util.sanitizeCorDappName
  */
 @CordaDslMarker
 class CordaNetwork private constructor() : ContainerCoordinates(
-    ORGANIZATION, DEFAULT_IMAGE, DEFAULT_TAG
+    DEFAULT_ORGANIZATION, DEFAULT_IMAGE, DEFAULT_TAG
 ) {
 
     /**

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -55,6 +55,14 @@ class CordaNetwork private constructor() {
      */
     lateinit var nodes: List<CordaPartyNode>
 
+    /**
+     * Docker image version for Network Map, by default `latest`.
+     */
+    var mapVersion: String = NETWORK_MAP_VERSION
+
+    /**
+     * Network Map instance to access the API.
+     */
     val map: NetworkMap by lazy {
         NetworkMap.build(CordaService("http://localhost:${mapContainer.getMappedPort(NETWORK_MAP_PORT)}"))
     }
@@ -95,7 +103,7 @@ class CordaNetwork private constructor() {
      * Cordite network map Docker container.
      */
     private val mapContainer: KGenericContainer by lazy {
-        KGenericContainer(NETWORK_MAP_IMAGE)
+        KGenericContainer("$NETWORK_MAP_IMAGE:$mapVersion")
             .withCreateContainerCmdModifier {
                 it.withHostName(mapName)
                 it.withName(mapName)
@@ -170,7 +178,8 @@ class CordaNetwork private constructor() {
     }
 
     companion object {
-        private const val NETWORK_MAP_IMAGE = "cordite/network-map:latest"
+        private const val NETWORK_MAP_VERSION = "latest"
+        private const val NETWORK_MAP_IMAGE = "cordite/network-map"
         private const val NETWORK_MAP_ALIAS = "network-map"
         private const val NETWORK_MAP_PORT = 8080
 

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -12,24 +12,24 @@
  */
 package org.web3j.corda.network
 
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardCopyOption.REPLACE_EXISTING
-import java.util.function.Consumer
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.idea.IdeaProject
 import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
 import org.testcontainers.containers.Network
 import org.web3j.corda.network.CordaNetworkMap.Companion.DEFAULT_IMAGE
-import org.web3j.corda.network.CordaNetworkMap.Companion.DEFAULT_TAG
 import org.web3j.corda.network.CordaNetworkMap.Companion.DEFAULT_ORGANIZATION
+import org.web3j.corda.network.CordaNetworkMap.Companion.DEFAULT_TAG
 import org.web3j.corda.networkmap.NetworkMapApi
 import org.web3j.corda.protocol.CordaService
 import org.web3j.corda.util.OpenApiVersion.v3_0_1
 import org.web3j.corda.util.isMac
 import org.web3j.corda.util.sanitizeCorDappName
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.util.function.Consumer
 
 /**
  * Corda network DSK for integration tests web3j CorDapp wrappers.
@@ -189,8 +189,10 @@ class CordaNetwork private constructor() : ContainerCoordinates(
                 map = CordaNetworkMap(this)
 
                 // Auto-start notaries and nodes
-                (notaries + parties).onEach {
-                    if (it.autoStart) { it.start() }
+                (notaries + parties).filter {
+                    it.autoStart
+                }.onEach {
+                    it.start()
                 }
             }
         }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -12,6 +12,11 @@
  */
 package org.web3j.corda.network
 
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.util.function.Consumer
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.model.idea.IdeaProject
@@ -25,11 +30,6 @@ import org.web3j.corda.protocol.CordaService
 import org.web3j.corda.util.OpenApiVersion.v3_0_1
 import org.web3j.corda.util.isMac
 import org.web3j.corda.util.sanitizeCorDappName
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardCopyOption.REPLACE_EXISTING
-import java.util.function.Consumer
 
 /**
  * Corda network DSK for integration tests web3j CorDapp wrappers.

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -189,7 +189,7 @@ class CordaNetwork private constructor() : ContainerCoordinates(
                 map = CordaNetworkMap(this).apply {
                     start()
                 }
-                
+
                 // Auto-start notaries and nodes
                 (notaries + parties).filter {
                     it.autoStart

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -131,7 +131,7 @@ class CordaNetwork private constructor() : ContainerCoordinates(
             nodesBlock.accept(this)
         }.also {
             notaries = it.notaries
-            parties = it.nodes
+            parties = it.parties
         }
     }
 

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -186,8 +186,10 @@ class CordaNetwork private constructor() : ContainerCoordinates(
                 networkBlock.accept(this)
 
                 // Initialize a network map
-                map = CordaNetworkMap(this)
-
+                map = CordaNetworkMap(this).apply {
+                    start()
+                }
+                
                 // Auto-start notaries and nodes
                 (notaries + parties).filter {
                     it.autoStart

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetwork.kt
@@ -57,17 +57,17 @@ class CordaNetwork private constructor() : ContainerCoordinates(
     /**
      * The nodes in this network.
      */
-    lateinit var nodes: List<CordaPartyNode>
+    lateinit var parties: List<CordaPartyNode>
 
     /**
      * Client API to interact with this network.
      */
-    val api: NetworkMapApi = map.instance.api
+    val api: NetworkMapApi by lazy { map.instance.api }
 
     /**
      * Corda service for this network.
      */
-    val service: CordaService = map.instance.service
+    val service: CordaService by lazy { map.instance.service }
 
     /**
      * Make container tag settable.
@@ -131,7 +131,7 @@ class CordaNetwork private constructor() : ContainerCoordinates(
             nodesBlock.accept(this)
         }.also {
             notaries = it.notaries
-            nodes = it.nodes
+            parties = it.nodes
         }
     }
 
@@ -184,10 +184,14 @@ class CordaNetwork private constructor() : ContainerCoordinates(
         fun networkJava(networkBlock: Consumer<CordaNetwork>): CordaNetwork {
             return CordaNetwork().apply {
                 networkBlock.accept(this)
+
                 // Initialize a network map
                 map = CordaNetworkMap(this)
-                // Auto-start network nodes if specified
-                nodes.filter { it.autoStart }.onEach { it.start() }
+
+                // Auto-start notaries and nodes
+                (notaries + parties).onEach {
+                    if (it.autoStart) { it.start() }
+                }
             }
         }
     }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkDsl.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkDsl.kt
@@ -28,6 +28,11 @@ fun CordaNetwork.nodes(nodesBlock: CordaNodes.() -> Unit) {
 }
 
 @CordaDslMarker
+fun CordaNetwork.map(mapBlock: CordaNetworkMap.() -> Unit) {
+    mapJava(Consumer { mapBlock.invoke(it) })
+}
+
+@CordaDslMarker
 fun CordaNodes.party(partyBlock: CordaPartyNode.() -> Unit) {
     partyJava(Consumer { partyBlock.invoke(it) })
 }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkDsl.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkDsl.kt
@@ -28,11 +28,6 @@ fun CordaNetwork.nodes(nodesBlock: CordaNodes.() -> Unit) {
 }
 
 @CordaDslMarker
-fun CordaNetwork.map(mapBlock: CordaNetworkMap.() -> Unit) {
-    mapJava(Consumer { mapBlock.invoke(it) })
-}
-
-@CordaDslMarker
 fun CordaNodes.party(partyBlock: CordaPartyNode.() -> Unit) {
     partyJava(Consumer { partyBlock.invoke(it) })
 }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
@@ -48,9 +48,9 @@ class CordaNetworkMap internal constructor(network: CordaNetwork) {
         }.apply { start() }
 
     companion object {
-        internal const val ORGANIZATION = "cordite"
+        internal const val DEFAULT_ORGANIZATION = "cordite"
         internal const val DEFAULT_IMAGE = "network-map"
-        internal const val DEFAULT_TAG = "v0.4.6"
+        internal const val DEFAULT_TAG = "v0.4.5"
         internal const val PORT = 8080
     }
 }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
@@ -22,7 +22,7 @@ class CordaNetworkMap internal constructor(network: CordaNetwork) {
     /**
      * Container URL inside the Docker network.
      */
-    internal val url = "http://$$DEFAULT_IMAGE-${System.currentTimeMillis()}:$PORT"
+    internal val url = "http://$DEFAULT_IMAGE-${System.currentTimeMillis()}:$PORT"
 
     /**
      * Network Map instance to access the API.
@@ -34,24 +34,23 @@ class CordaNetworkMap internal constructor(network: CordaNetwork) {
     /**
      * Cordite network map Docker container.
      */
-    private val container: KGenericContainer by lazy {
-        KGenericContainer(toString())
-            .withCreateContainerCmdModifier {
-                it.withHostName(network.image)
-                it.withName(network.image)
-            }.withNetwork(network.network)
-            .withNetworkAliases(network.image)
-            .withEnv("NMS_STORAGE_TYPE", "file")
-            .waitingFor(Wait.forHttp("").forPort(PORT))
-            .withLogConsumer {
-                CordaNode.logger.info { it.utf8String.trimEnd() }
-            }.apply { start() }
-    }
+    private val container = KGenericContainer(network.toString())
+        .withCreateContainerCmdModifier {
+            it.withHostName(network.image)
+            it.withName(network.image)
+        }.withNetwork(network.network)
+        .withNetworkAliases(network.image)
+        .withEnv("NMS_STORAGE_TYPE", "file")
+        .waitingFor(Wait.forHttp("").forPort(PORT))
+        .withExposedPorts(PORT)
+        .withLogConsumer {
+            CordaNode.logger.info { it.utf8String.trimEnd() }
+        }.apply { start() }
 
     companion object {
         internal const val ORGANIZATION = "cordite"
         internal const val DEFAULT_IMAGE = "network-map"
-        internal const val DEFAULT_TAG = "v0.5.0"
+        internal const val DEFAULT_TAG = "v0.4.6"
         internal const val PORT = 8080
     }
 }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
@@ -1,0 +1,60 @@
+package org.web3j.corda.network
+
+import org.testcontainers.containers.wait.strategy.Wait
+import org.web3j.corda.networkmap.NetworkMapApi
+import org.web3j.corda.protocol.CordaService
+import org.web3j.corda.protocol.NetworkMap
+import org.web3j.corda.testcontainers.KGenericContainer
+
+@CordaDslMarker
+class CordaNetworkMap internal constructor(network: CordaNetwork) {
+
+    /**
+     * Host name inside the Docker container network.
+     */
+    private val name = "${NETWORK_MAP_IMAGE}-${System.currentTimeMillis()}"
+
+    /**
+     * Container URL inside the Docker network.
+     */
+    internal val url = "http://$name:${NETWORK_MAP_PORT}"
+
+    /**
+     * Docker image tag, by default `edge`.
+     */
+    var tag: String = NETWORK_MAP_DEFAULT_TAG
+
+    /**
+     * Network Map instance to access the API.
+     */
+    private val instance: NetworkMap by lazy {
+        NetworkMap.build(CordaService("http://localhost:${container.getMappedPort(NETWORK_MAP_PORT)}"))
+    }
+    
+    val api: NetworkMapApi = instance.api
+    val service: CordaService = instance.service
+
+    /**
+     * Cordite network map Docker container.
+     */
+    private val container: KGenericContainer by lazy {
+        KGenericContainer("$NETWORK_MAP_ORGANIZATION/$NETWORK_MAP_IMAGE:$tag")
+            .withCreateContainerCmdModifier {
+                it.withHostName(name)
+                it.withName(name)
+            }.withNetwork(network.network)
+            .withNetworkAliases(name)
+            .withEnv("NMS_STORAGE_TYPE", "file")
+            .waitingFor(Wait.forHttp("").forPort(NETWORK_MAP_PORT))
+            .withLogConsumer {
+                CordaNode.logger.info { it.utf8String.trimEnd() }
+            }.apply { start() }
+    }
+
+    companion object {
+        private const val NETWORK_MAP_ORGANIZATION = "cordite"
+        private const val NETWORK_MAP_DEFAULT_TAG = "edge"
+        private const val NETWORK_MAP_IMAGE = "network-map"
+        private const val NETWORK_MAP_PORT = 8080
+    }
+}

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNetworkMap.kt
@@ -50,7 +50,7 @@ class CordaNetworkMap internal constructor(network: CordaNetwork) {
     companion object {
         internal const val DEFAULT_ORGANIZATION = "cordite"
         internal const val DEFAULT_IMAGE = "network-map"
-        internal const val DEFAULT_TAG = "v0.4.5"
+        internal const val DEFAULT_TAG = "v0.5.0"
         internal const val PORT = 8080
     }
 }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
@@ -38,6 +38,11 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
     lateinit var name: String
 
     /**
+     * Docker image version for this Corda node, by default `latest`.
+     */
+    var cordaVersion: String = CORDA_ZULU_VERSION
+
+    /**
      * Corda P2P port for this node.
      */
     var p2pPort: Int = randomPort()
@@ -88,7 +93,7 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
         createNodeConfFiles(nodeDir.resolve("node.conf"))
         saveCertificateFromNetworkMap(nodeDir)
 
-        KGenericContainer(CORDA_ZULU_IMAGE)
+        KGenericContainer("$CORDA_ZULU_IMAGE:$cordaVersion")
             .withNetwork(network.network)
             .withExposedPorts(p2pPort, rpcPort, adminPort)
             .withFileSystemBind(
@@ -165,7 +170,8 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
     }
 
     companion object : KLogging() {
-        private const val CORDA_ZULU_IMAGE = "corda/corda-zulu-4.1:latest"
+        private const val CORDA_ZULU_VERSION = "latest"
+        private const val CORDA_ZULU_IMAGE = "corda/corda-zulu-4.1"
 
         private val portRange = 1024..65535
 

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
@@ -70,11 +70,6 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
     }
 
     /**
-     * Is this a notary node?
-     */
-    open val isNotary: Boolean = false
-
-    /**
      * Make container image settable.
      */
     override var image = super.image
@@ -158,7 +153,8 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
             nodeConfTemplate.execute(
                 mapOf(
                     "name" to name,
-                    "isNotary" to isNotary,
+                    "isNotary" to (this is CordaNotaryNode),
+                    "isValidating" to ((this is CordaNotaryNode) && validating),
                     "p2pAddress" to "$canonicalName:$p2pPort",
                     "rpcPort" to rpcPort,
                     "adminPort" to adminPort,

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
@@ -30,6 +30,7 @@ import org.web3j.corda.util.canonicalName
 /**
  * Corda network node exposing a Corda API through a Braid container.
  */
+@CordaDslMarker
 abstract class CordaNode internal constructor(protected val network: CordaNetwork) {
 
     /**
@@ -103,8 +104,8 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
                 nodeDir.resolve("certificates").absolutePath,
                 "/opt/corda/certificates",
                 BindMode.READ_WRITE
-            ).withEnv("NETWORKMAP_URL", network.mapUrl)
-            .withEnv("DOORMAN_URL", network.mapUrl)
+            ).withEnv("NETWORKMAP_URL", network.map.url)
+            .withEnv("DOORMAN_URL", network.map.url)
             .withEnv("NETWORK_TRUST_PASSWORD", "trustpass")
             .withEnv("MY_PUBLIC_ADDRESS", "http://localhost:$p2pPort")
             .withCommand("config-generator --generic")
@@ -155,7 +156,7 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
                     "p2pAddress" to "$canonicalName:$p2pPort",
                     "rpcPort" to rpcPort,
                     "adminPort" to adminPort,
-                    "networkMapUrl" to network.mapUrl
+                    "networkMapUrl" to network.map.url
                 ),
                 it
             )

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
@@ -31,9 +31,8 @@ import org.web3j.corda.util.canonicalName
  * Corda network node exposing a Corda API through a Braid container.
  */
 @CordaDslMarker
-abstract class CordaNode internal constructor(protected val network: CordaNetwork) : ContainerCoordinates(
-    DEFAULT_ORGANIZATION, DEFAULT_IMAGE, DEFAULT_TAG
-) {
+abstract class CordaNode internal constructor(protected val network: CordaNetwork) : ContainerLifecycle,
+    ContainerCoordinates(DEFAULT_ORGANIZATION, DEFAULT_IMAGE, DEFAULT_TAG) {
     /**
      * X.500 name for this Corda node, eg. `O=Notary, L=London, C=GB`.
      */
@@ -124,7 +123,7 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
     /**
      * Start this Corda node.
      */
-    open fun start() {
+    override fun start() {
         logger.info("Starting Corda node $canonicalName...")
         container.start()
         logger.info("Started Corda node $canonicalName.")
@@ -133,7 +132,7 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
     /**
      * Stop this Corda node.
      */
-    open fun stop() {
+    override fun stop() {
         logger.info("Stopping Corda node $canonicalName...")
         container.stop()
         logger.info("Stopped Corda node $canonicalName.")
@@ -167,7 +166,7 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
     }
 
     private fun saveCertificateFromNetworkMap(nodeDir: File) {
-        val certificateFolder = File(nodeDir, "certificates").apply { mkdir() }
+        val certificateFolder = File(nodeDir, "certificates").apply { mkdirs() }
         val certificateFile = certificateFolder.resolve("network-root-truststore.jks")
         Files.write(certificateFile.toPath(), network.api.networkMap.truststore)
     }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNode.kt
@@ -32,7 +32,7 @@ import org.web3j.corda.util.canonicalName
  */
 @CordaDslMarker
 abstract class CordaNode internal constructor(protected val network: CordaNetwork) : ContainerCoordinates(
-    ORGANIZATION, DEFAULT_IMAGE, DEFAULT_TAG
+    DEFAULT_ORGANIZATION, DEFAULT_IMAGE, DEFAULT_TAG
 ) {
     /**
      * X.500 name for this Corda node, eg. `O=Notary, L=London, C=GB`.
@@ -177,7 +177,7 @@ abstract class CordaNode internal constructor(protected val network: CordaNetwor
     }
 
     companion object : KLogging() {
-        private const val ORGANIZATION = "corda"
+        private const val DEFAULT_ORGANIZATION = "corda"
         private const val DEFAULT_IMAGE = "corda-zulu-4.1"
         private const val DEFAULT_TAG = "latest"
 

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNodes.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNodes.kt
@@ -14,6 +14,7 @@ package org.web3j.corda.network
 
 import java.util.function.Consumer
 
+@CordaDslMarker
 class CordaNodes internal constructor(private val network: CordaNetwork) {
 
     internal val notaries = mutableListOf<CordaNotaryNode>()
@@ -25,9 +26,6 @@ class CordaNodes internal constructor(private val network: CordaNetwork) {
             partyBlock.accept(it)
             it.validate()
             nodes.add(it)
-            if (it.autoStart) {
-                it.start()
-            }
         }
     }
 

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNodes.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNodes.kt
@@ -18,14 +18,14 @@ import java.util.function.Consumer
 class CordaNodes internal constructor(private val network: CordaNetwork) {
 
     internal val notaries = mutableListOf<CordaNotaryNode>()
-    internal val nodes = mutableListOf<CordaPartyNode>()
+    internal val parties = mutableListOf<CordaPartyNode>()
 
     @JvmName("party")
     fun partyJava(partyBlock: Consumer<CordaPartyNode>) {
         CordaPartyNode(network).also {
             partyBlock.accept(it)
             it.validate()
-            nodes.add(it)
+            parties.add(it)
         }
     }
 

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNodes.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNodes.kt
@@ -35,9 +35,6 @@ class CordaNodes internal constructor(private val network: CordaNetwork) {
             notaryBlock.accept(it)
             it.validate()
             notaries.add(it)
-            if (it.autoStart) {
-                it.start()
-            }
         }
     }
 }

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNotaryNode.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNotaryNode.kt
@@ -27,7 +27,10 @@ import org.web3j.corda.testcontainers.KGenericContainer
  */
 class CordaNotaryNode internal constructor(network: CordaNetwork) : CordaNode(network) {
 
-    override val isNotary: Boolean = true
+    /**
+     * Is this a validating notary?
+     */
+    var validating: Boolean = false
 
     override fun KGenericContainer.configure(nodeDir: File) {
         logger.info("Starting notary container $canonicalName...")

--- a/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNotaryNode.kt
+++ b/common/src/integration-test/kotlin/org/web3j/corda/network/CordaNotaryNode.kt
@@ -33,7 +33,7 @@ class CordaNotaryNode internal constructor(network: CordaNetwork) : CordaNode(ne
         logger.info("Starting notary container $canonicalName...")
         start()
         logger.info("Started notary container $canonicalName.")
-        val prev = this@CordaNotaryNode.network.map.api.admin.networkMap().networkParameterHash
+        val prev = this@CordaNotaryNode.network.api.admin.networkMap().networkParameterHash
         extractNotaryNodeInfo(nodeDir).also {
             updateNotaryInNetworkMap(nodeDir.resolve(it).absolutePath)
         }
@@ -61,15 +61,15 @@ class CordaNotaryNode internal constructor(network: CordaNetwork) : CordaNode(ne
 
     private fun updateNotaryInNetworkMap(nodeInfoPath: String) {
         val loginRequest = LoginRequest("sa", "admin")
-        val token = network.map.api.admin.login(loginRequest)
-        val authMap = NetworkMap.build(CordaService(network.map.service.uri), token)
+        val token = network.api.admin.login(loginRequest)
+        val authMap = NetworkMap.build(CordaService(network.service.uri), token)
 
         logger.info("Creating a non-validating notary in network map with node info $nodeInfoPath")
         authMap.api.admin.notaries.create(NotaryType.NON_VALIDATING, Files.readAllBytes(Paths.get(nodeInfoPath)))
     }
 
     private fun waitForNetworkMapHashUpdate(prevNetworkMapHash: String) {
-        while (network.map.api.admin.networkMap().networkParameterHash == prevNetworkMapHash) {
+        while (network.api.admin.networkMap().networkParameterHash == prevNetworkMapHash) {
             TimeUnit.MILLISECONDS.sleep(5000)
             logger.info("waiting for Network Map to update the Hash ")
         }

--- a/common/src/integration-test/resources/node_conf.mustache
+++ b/common/src/integration-test/resources/node_conf.mustache
@@ -2,7 +2,7 @@ devMode=true
 myLegalName="{{&name}}"
 {{#isNotary}}
 notary {
-    validating=false
+    validating={{isValidating}}
 }
 {{/isNotary}}
 p2pAddress="{{&p2pAddress}}"

--- a/console/src/integration-test/java/org/web3j/corda/examples/obligation/ObligationJavaTest.java
+++ b/console/src/integration-test/java/org/web3j/corda/examples/obligation/ObligationJavaTest.java
@@ -32,7 +32,7 @@ public class ObligationJavaTest {
 
     @Test
     public void issueObligation() {
-        final Corda corda = getNetwork().getNodes().get(0).getCorda();
+        final Corda corda = getNetwork().getParties().get(0).getCorda();
 
         final Party partyB =
                 corda.getApi()

--- a/console/src/integration-test/kotlin/org/web3j/corda/examples/finance/CordaFinanceKotlinTest.kt
+++ b/console/src/integration-test/kotlin/org/web3j/corda/examples/finance/CordaFinanceKotlinTest.kt
@@ -28,10 +28,10 @@ class CordaFinanceKotlinTest {
     @Test
     fun `cash issue flow`() {
 
-        val notary = network.nodes[0].corda.api.network.notaries.findAll().first()
-        val partyA = network.nodes[0].corda.api.network.nodes.self
+        val notary = network.parties[0].corda.api.network.notaries.findAll().first()
+        val partyA = network.parties[0].corda.api.network.nodes.self
 
-        CordaFinanceWorkflows.load(network.nodes[0].corda.service).flows.cashIssueFlow.start(
+        CordaFinanceWorkflows.load(network.parties[0].corda.service).flows.cashIssueFlow.start(
             CashIssueFlowPayload(
                 amount = AmountCurrency(100, BigDecimal.valueOf(0.01), "GBP"),
                 issuerBankPartyRef = OpaqueBytes("736F6D654279746573"),
@@ -44,11 +44,11 @@ class CordaFinanceKotlinTest {
 
     @Test
     fun `cash issue and payment flow`() {
-        val notary = network.nodes[0].corda.api.network.notaries.findAll().first()
-        val partyB = network.nodes[0].corda.api.network.nodes
+        val notary = network.parties[0].corda.api.network.notaries.findAll().first()
+        val partyB = network.parties[0].corda.api.network.nodes
             .findByX500Name("O=PartyB,L=New York,C=US")[0].legalIdentities[0]
 
-        CordaFinanceWorkflows.load(network.nodes[0].corda.service).flows.cashIssueAndPaymentFlow.start(
+        CordaFinanceWorkflows.load(network.parties[0].corda.service).flows.cashIssueAndPaymentFlow.start(
             CashIssueAndPaymentFlowPayload(
                 amount = AmountCurrency(100, BigDecimal.valueOf(0.01), "GBP"),
                 issueRef = OpaqueBytes("736F6D654279746573"),

--- a/console/src/integration-test/kotlin/org/web3j/corda/examples/obligation/ObligationKotlinTest.kt
+++ b/console/src/integration-test/kotlin/org/web3j/corda/examples/obligation/ObligationKotlinTest.kt
@@ -26,10 +26,10 @@ class ObligationKotlinTest {
     @Test
     fun `issue obligation`() {
 
-        val partyB = network.nodes[0].corda.api.network.nodes
+        val partyB = network.parties[0].corda.api.network.nodes
             .findByX500Name("O=PartyB,L=New York,C=US")[0].legalIdentities[0]
 
-        Obligation.load(network.nodes[0].corda.service).flows.issueObligationInitiator.start(
+        Obligation.load(network.parties[0].corda.service).flows.issueObligationInitiator.start(
             IssueObligation_InitiatorPayload(
                 AmountCurrency(100, BigDecimal.ONE, "GBP"),
                 partyB,

--- a/console/src/integration-test/kotlin/org/web3j/corda/examples/yo/YoKotlinTest.kt
+++ b/console/src/integration-test/kotlin/org/web3j/corda/examples/yo/YoKotlinTest.kt
@@ -23,10 +23,10 @@ class YoKotlinTest {
 
     @Test
     fun `send Yo`() {
-        val partyB = network.nodes[0].corda.api.network.nodes
+        val partyB = network.parties[0].corda.api.network.nodes
             .findByX500Name("O=PartyB, L=New York, C=US")[0].legalIdentities[0]
 
-        Yo.load(network.nodes[0].corda.service).flows.yoFlow.start(
+        Yo.load(network.parties[0].corda.service).flows.yoFlow.start(
             YoFlowPayload(partyB)
         ).apply {
             assertThat(coreTransaction!!.outputs[0].data!!.participants?.first()?.owningKey).isEqualTo(partyB.owningKey)

--- a/core/src/integration-test/kotlin/org/web3j/corda/api/CordaIntegrationTest.kt
+++ b/core/src/integration-test/kotlin/org/web3j/corda/api/CordaIntegrationTest.kt
@@ -34,7 +34,7 @@ class CordaIntegrationTest {
 
     @Test
     fun `corDapps resource`() {
-        with(network.nodes[0].corda.api) {
+        with(network.parties[0].corda.api) {
             assertThat(corDapps.findAll()).containsOnly("braid-server")
             assertThat(corDapps.findById("braid-server").flows.findAll()).isEmpty()
         }
@@ -42,7 +42,7 @@ class CordaIntegrationTest {
 
     @Test
     fun `network resource`() {
-        with(network.nodes[0].corda.api) {
+        with(network.parties[0].corda.api) {
             network.nodes.self.apply {
                 assertThat(legalIdentities).hasSize(1)
                 assertThat(legalIdentities.first().name).isEqualTo(PARTY)
@@ -56,7 +56,7 @@ class CordaIntegrationTest {
                 assertThat(this).hasSize(1)
                 assertThat(first().legalIdentities.map { it.name }).containsOnly(PARTY)
             }
-            val p2pPort = this@CordaIntegrationTest.network.nodes[0].p2pPort
+            val p2pPort = this@CordaIntegrationTest.network.parties[0].p2pPort
             network.nodes.findByHostAndPort("party-new-york-us:$p2pPort").apply {
                 assertThat(this).hasSize(1)
                 assertThat(first().legalIdentities.map { it.name }).containsOnly(PARTY)

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,29 @@
+Writing tests
+=============
+
+Define a test network
+
+In a similar way as you can define CordForm networks to test your CordDapp flows,
+
+```kotlin
+val network = network {
+    nodes {
+        notary {
+            name = "O=Notary, L=London, C=GB"                                         
+        }
+        party {
+            name = "O=PartyA, L=London, C=GB"
+        }
+        party {
+            name = "O=PartyB, L=New York, C=US"
+        }
+    }
+}
+```
+
+You can the access the nodes in the network by its index:
+
+```kotlin
+network.notaries[0] // Returns the Notary node
+network.parties[0] // Returns the PartyA node
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Working with Client Wrappers : usage.md
   - Network Queries : network.md
   - Command Line Tools: command_line_tools.md
+  - Writing tests: tests.md
   - Examples: examples.md
   - Support: support.md
 


### PR DESCRIPTION
Adds `cordaVersion` and `mapVersion` to the Corda network DSL.

To discuss the field names. Should also the Docker image name be customisable or only the version?